### PR TITLE
macOS Catalyst Functionality Fix

### DIFF
--- a/.github/workflows/BuildTests.yml
+++ b/.github/workflows/BuildTests.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Force Xcode 13.2.1
         run: sudo xcode-select -switch /Applications/Xcode_13.2.1.app
 
-      - name: Build Setup
+      - name: Test
         run: swift test
 

--- a/Sources/RichEditor/Classes/RichEditor/RichEditor+Stack.swift
+++ b/Sources/RichEditor/Classes/RichEditor/RichEditor+Stack.swift
@@ -19,26 +19,39 @@ extension RichEditor {
      - parameter isHorizontalScrollingEnabled: If true, the NSTextView will allow horizontal scrolling
     */
     internal func configureTextView(isHorizontalScrollingEnabled: Bool) {
-        self.textStorage.addLayoutManager(self.layoutManager)
-        self.layoutManager.addTextContainer(self.textContainer)
-        
         let contentSize = self.scrollview.contentSize
         
+        self.textStorage.addLayoutManager(self.layoutManager)
+        self.layoutManager.addTextContainer(self.textContainer)
+                
         if isHorizontalScrollingEnabled {
-            self.textContainer.containerSize = CGSize(width: CGFloat.greatestFiniteMagnitude,
-                                                      height: CGFloat.greatestFiniteMagnitude)
+            self.textContainer.containerSize = CGSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
             self.textContainer.widthTracksTextView = false
         }
         else {
-            self.textContainer.containerSize = CGSize(width: contentSize.width, height: CGFloat.greatestFiniteMagnitude)
+            self.textContainer.containerSize = CGSize(
+                width: contentSize.width,
+                height: CGFloat.greatestFiniteMagnitude
+            )
             self.textContainer.widthTracksTextView = true
         }
         
         self.textView.minSize = CGSize(width: 0, height: 0)
-        self.textView.maxSize = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        self.textView.maxSize = CGSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
         self.textView.isVerticallyResizable = true
         self.textView.isHorizontallyResizable = isHorizontalScrollingEnabled
-        self.textView.frame = CGRect(x: 0, y: 0, width: contentSize.width, height: contentSize.height)
+        self.textView.frame = CGRect(
+            x: 0,
+            y: 0,
+            width: contentSize.width,
+            height: contentSize.height
+        )
         
         if isHorizontalScrollingEnabled {
             textView.autoresizingMask = [.width, .height]

--- a/Sources/RichEditor/Classes/RichEditor/RichEditor.swift
+++ b/Sources/RichEditor/Classes/RichEditor/RichEditor.swift
@@ -107,6 +107,19 @@ private extension RichEditor {
      Perform the initial setup operations to get a functional NSTextView running
     */
     func setup() {
+        /// This line of code here is disgusting.
+        /// The only reason it's here is because of an NSTextView issue that only pops up
+        /// when launching this library from a iOS -> Catalyst application. A very edge case scenario
+        /// but one that we should account for.
+        ///
+        /// I'll be on the lookout for when Apple fixes this :)
+        ///
+        guard self.scrollview.contentSize != .zero else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
+                self.setup()
+            }
+            return
+        }
         self.textView.delegate = self
 
         self.configureTextView(isHorizontalScrollingEnabled: false)


### PR DESCRIPTION
Due to a niche use case when this library is launched from an iOS application supporting macOS catalyst, a `NSTextView`/`NSScrollView` bug surfaces where the `NSScrollView`s `contentSize` is considered to be `.zero` when it's not.

This is a very hacky fix to resolve this issue.